### PR TITLE
Standard Errors named incorrectly

### DIFF
--- a/lab13/lab13.Rmd
+++ b/lab13/lab13.Rmd
@@ -80,7 +80,7 @@ fit2 = lm(wage~ns(age, df = 4), data = Wage)
 pred2 = predict(fit2, newdata = list(age = age_grid), se = TRUE)
 
 # Compute error bands (2*SE)
-se_bands = with(pred, cbind("upper" = fit+2*se.fit, 
+se_bands2 = with(pred, cbind("upper" = fit+2*se.fit, 
                             "lower" = fit-2*se.fit))
 
 # Plot the natural spline and error bands


### PR DESCRIPTION
When discussing the natural splines, the standard error are called using the name se_bands2 in the ggplot argument but earlier the variable is named se_bands.